### PR TITLE
moved indicator to separate fields block

### DIFF
--- a/maps/forms.py
+++ b/maps/forms.py
@@ -81,6 +81,8 @@ class CreateReviewForm(forms.ModelForm):
         decision_making_field_groups_by_indicator.extend(fields_of(
             'has_explicit_indication_of_target_audience',
             'explicit_target_audience_text_explanation',
+        ))
+        decision_making_field_groups_by_indicator.extend(fields_of(
             'has_potential_target_audience',
             'potential_target_audience_text',
         ))


### PR DESCRIPTION
@geojayuu this was just to fix that nested problem. The `fields_of` method takes the indicator name as its first arg, all that follow are nested inside so I just had to extend the list with another call to `fields_of` with the indicator first. :)
